### PR TITLE
Use a smaller set of peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/girder/eslint-config-girder.git"
   },
   "peerDependencies": {
-    "eslint-config-semistandard": "^6.0.2"
+    "eslint-config-semistandard": ">=6.0.2"
   },
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,7 @@
     "url": "https://github.com/girder/eslint-config-girder.git"
   },
   "peerDependencies": {
-    "eslint": "^3.3.1",
-    "eslint-config-semistandard": "^6.0.2",
-    "eslint-config-standard": "^5.3.5",
-    "eslint-plugin-backbone": "^2.0.2",
-    "eslint-plugin-promise": "^2.0.1",
-    "eslint-plugin-standard": "^2.0.0",
-    "eslint-plugin-underscore": "0.0.10"
+    "eslint-config-semistandard": "^6.0.2"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
peerDependencies should contain only those packages that this directly depends on, which is just eslint-config-semistandard. Other eslint packages will be transitive dependencies.

This will make this package much more flexible to use and upgrade with other eslint versions in the future.