### PR TITLE
Correct name of eslint-plugin-backbone in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install
 -------
 
 ```
-npm install --save-dev eslint-config-girder eslint@3.3.1 eslint-config-semistandard@6.0.2 eslint-config-standard@5.3.5 eslint-config-backbone@2.0.2 eslint-plugin-promise@2.0.1 eslint-plugin-standard@2.0.0 eslint-plugin-underscore@0.0.10
+npm install --save-dev eslint-config-girder eslint@3.3.1 eslint-config-semistandard@6.0.2 eslint-config-standard@5.3.5 eslint-plugin-backbone@2.0.2 eslint-plugin-promise@2.0.1 eslint-plugin-standard@2.0.0 eslint-plugin-underscore@0.0.10
 ```
 
 Usage


### PR DESCRIPTION
`eslint-config-backbone` is not an npm package. Corrected to reference `eslint-plugin-backbone` in install instructions.